### PR TITLE
log.html: add UTC to timestamps

### DIFF
--- a/data/templates/log.html
+++ b/data/templates/log.html
@@ -8,7 +8,7 @@
   {% set data = log.getData() %}
   <tbody>
   <tr>
-    <th colspan="4">{{ data['@timestamp']|date('Y-m-d') }} - <a href="{{ urlFor( 'SAL', { 'project': data['project'] } ) }}">{{ data['project'] }}</a></th>
+    <th colspan="4">{{ data['@timestamp']|date('Y-m-d') }} UTC - <a href="{{ urlFor( 'SAL', { 'project': data['project'] } ) }}">{{ data['project'] }}</a></th>
   </tr>
   {% include 'inc/log.html' %}
   {% endfor %}


### PR DESCRIPTION
That way it's clear that they are expected to be UTC times.

There might be a smarter way to get the timezone, though as I understand it, we are already expecting it to be UTC, so just surfacing that in the UI.